### PR TITLE
Fixed the build process when using the latest version of Rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "istanbul": "^0.4.3",
     "minimist": "^1.2.0",
     "mocha": "^3.0.2",
-    "rollup": "^0.36.3",
+    "rollup": "^0.45.2",
     "rollup-plugin-istanbul": "^1.1.0",
     "source-map-support": "^0.4.2",
     "spectron": "^3.3.0"

--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -37,17 +37,18 @@ module.exports = function (src, dest, opts) {
         cached[src] = bundle;
 
         var jsFile = path.basename(dest);
-        var result = bundle.generate({
+        return bundle.generate({
             format: 'cjs',
             sourceMap: true,
             sourceMapFile: jsFile
-        });
-        // Wrap code in self invoking function so the variables don't
-        // pollute the global namespace.
-        var isolatedCode = '(function () {' + result.code + '\n}());';
-        return Promise.all([
-            jetpack.writeAsync(dest, isolatedCode + '\n//# sourceMappingURL=' + jsFile + '.map'),
-            jetpack.writeAsync(dest + '.map', result.map.toString()),
-        ]);
+        }).then(result => {
+          // Wrap code in self invoking function so the variables don't
+          // pollute the global namespace.
+          var isolatedCode = '(function () {' + result.code + '\n}());';
+          return Promise.all([
+              jetpack.writeAsync(dest, isolatedCode + '\n//# sourceMappingURL=' + jsFile + '.map'),
+              jetpack.writeAsync(dest + '.map', result.map.toString()),
+          ]);
+		});
     });
 };


### PR DESCRIPTION
Rollup's bundle.generate(...) method now returns a Promise instead of a { code, map } object, which was breaking the build process. I fixed that.