### PR TITLE
listView Filter Improvements

### DIFF
--- a/app/directives/listView.html
+++ b/app/directives/listView.html
@@ -1,5 +1,5 @@
 <div class="list-items" ng-class="{'dragging' : dragging}">
-    <div ng-repeat="item in items" class="list-item" ng-class="{'selected': item.selected}" ng-mousedown="onItemMouseDown($event, $index)" ng-drag="onItemDrag($event, $index)" ng-drop="onItemDrop($event, $index)" drag-over="onItemDragOver($event, $index)" drag-leave="onItemDragLeave($event)" ng-transclude></div>
+    <div ng-repeat="item in items | listViewFilter:filterItems:filterOptions as filteredItems" class="list-item" ng-class="{'selected': item.selected}" ng-mousedown="onItemMouseDown($event, $index)" ng-drag="onItemDrag($event, $index)" ng-drop="onItemDrop($event, $index)" drag-over="onItemDragOver($event, $index)" drag-leave="onItemDragLeave($event)" ng-transclude></div>
     <div ng-if="!items.length && dragType" class="placeholder" ng-drop="onPlaceholderDrop($event)" drag-over="onPlaceholderDragOver()"></div>
 </div>
 <div class="filter-container" ng-if="filterItems">
@@ -9,4 +9,8 @@
             <input type="text" ng-model="item.text" ng-change="filterChanged()" ng-keydown="onFilterKeyDown($event)" autofocus />
         </label>
     </div>
+    <label>
+        <input type="checkbox" ng-model="filterOptions.onlyShowMatches" ng-change="onOnlyShowMatchesChanged()"/>
+        Only show matches
+    </label>
 </div>

--- a/src/javascripts/Directives/listView.js
+++ b/src/javascripts/Directives/listView.js
@@ -233,7 +233,11 @@ ngapp.controller('listViewController', function($scope, $timeout, $element, hotk
             }, true);
         });
         if (index === -1) {
-            if (isNew) return;
+            if (isNew || firstFilteredIndex === -1) {
+                firstFilteredIndex = -1;
+                return;
+            }
+            // The end has been reached; cycle back to the start.
             index = firstFilteredIndex;
         }
         $scope.selectItem({}, index);

--- a/src/javascripts/Directives/listView.js
+++ b/src/javascripts/Directives/listView.js
@@ -249,10 +249,16 @@ ngapp.controller('listViewController', function($scope, $timeout, $element, hotk
         if (onSameItem(dragData, e, index)) return;
         let after = e.offsetY > (e.target.offsetHeight / 2),
             lengthBefore = $scope.filteredItems.length,
-            movedItem = dragData.getItem(),
+            movedItem = dragData.getItem(), // The item is removed in-place.
             adjust = lengthBefore > $scope.filteredItems.length && index > dragData.index;
         removeClasses(e.target);
-        $scope.items.splice($scope.filteredItems[index + after - adjust].index, 0, movedItem);
+        // Translate the index to the one in the unfiltered items array. If the
+        // destination index is the end of the array, then there won't be an
+        // item at that index within filteredItems. In such case, the translated
+        // index should just be the last index in the items array + 1
+        // i.e. the length of the items array.
+        const spliceStart = index < $scope.filteredItems.length ? $scope.filteredItems[index].index : $scope.items.length;
+        $scope.items.splice(spliceStart + after - adjust, 0, movedItem);
         prevIndex.filteredValue = index + after - adjust;
         $scope.$emit('itemsReordered');
         return true;

--- a/src/javascripts/Directives/listView.js
+++ b/src/javascripts/Directives/listView.js
@@ -248,15 +248,24 @@ ngapp.controller('listViewController', function($scope, $timeout, $element, hotk
         if (!dragData || dragData.source !== $scope.dragType) return;
         if (onSameItem(dragData, e, index)) return;
         let after = e.offsetY > (e.target.offsetHeight / 2),
-            lengthBefore = $scope.filteredItems.length,
+            // This and adjust cannot use filteredItem's length because that
+            // array will still not be updated yet after getItem is called.
+            lengthBefore = $scope.items.length,
             movedItem = dragData.getItem(), // The item is removed in-place.
-            adjust = lengthBefore > $scope.filteredItems.length && index > dragData.index;
+            adjust = lengthBefore > $scope.items.length && index > dragData.index;
         removeClasses(e.target);
         // Translate the index to the one in the unfiltered items array. If the
         // destination index is the end of the array, then there won't be an
         // item at that index within filteredItems. In such case, the translated
         // index should just be the last index in the items array + 1
         // i.e. the length of the items array.
+        //
+        // It may seem like items.length is wrong to use when onlyShowMatches
+        // is true. However, when it's true, the item at that index will still
+        // exist in filteredItems because the array has not been updated yet to
+        // reflect the deletion caused by getItem(). It does reflect the change
+        // when onlyShowMatches is false because filteredItems then refers to
+        // the same array instance as `items`.
         const spliceStart = index < $scope.filteredItems.length ? $scope.filteredItems[index].index : $scope.items.length;
         $scope.items.splice(spliceStart + after - adjust, 0, movedItem);
         $scope.$emit('itemsReordered');

--- a/src/javascripts/Directives/listView.js
+++ b/src/javascripts/Directives/listView.js
@@ -24,6 +24,7 @@ ngapp.controller('listViewController', function($scope, $timeout, $element, hotk
 
     // helper variables
     let prevIndex = -1,
+        firstFilteredIndex = -1,
         eventListeners = {
             click: e => $scope.$apply(() => $scope.onParentClick(e)),
             keydown: e => $scope.$apply(() => {
@@ -220,15 +221,23 @@ ngapp.controller('listViewController', function($scope, $timeout, $element, hotk
         return true;
     };
 
-    $scope.filterChanged = function() {
+    $scope.filterChanged = function(isNew = true) {
         if (!$scope.filterItems) return;
-        let index = $scope.items.findIndex(item => {
+        let index = $scope.items.findIndex((item, i) => {
+            // Skip items that are before the previously selected index.
+            if (!isNew && i <= prevIndex) return false;
+
+            // Find the next index such that all filters are satisfied.
             return $scope.filterItems.reduce((b, f) => {
                 return b && f.filter(item, f.text);
             }, true);
         });
-        if (index === -1) return;
+        if (index === -1) {
+            if (isNew) return;
+            index = firstFilteredIndex;
+        }
         $scope.selectItem({}, index);
+        if (isNew) firstFilteredIndex = index;
     };
 
     $scope.$on('destroy', () => toggleEventListeners(false));

--- a/src/javascripts/Directives/listView.js
+++ b/src/javascripts/Directives/listView.js
@@ -259,8 +259,11 @@ ngapp.controller('listViewController', function($scope, $timeout, $element, hotk
         // i.e. the length of the items array.
         const spliceStart = index < $scope.filteredItems.length ? $scope.filteredItems[index].index : $scope.items.length;
         $scope.items.splice(spliceStart + after - adjust, 0, movedItem);
-        prevIndex.filteredValue = index + after - adjust;
         $scope.$emit('itemsReordered');
+        // Unfortunately, execution order is important here.
+        // This must happen after itemsReordered is handled.
+        // The setter relies on the `index` property of the item being updated.
+        prevIndex.filteredValue = index + after - adjust;
         return true;
     };
 

--- a/src/javascripts/Factories/hotkeyFactory.js
+++ b/src/javascripts/Factories/hotkeyFactory.js
@@ -282,14 +282,15 @@ ngapp.service('hotkeyFactory', function() {
         }]
     };
 
-    let closeFilter = (scope, e) => {
-        e.stopPropagation();
-        scope.toggleFilter(false);
-    };
-
     this.listViewFilterHotkeys = {
-        escape: closeFilter,
-        enter: closeFilter,
+        escape: (scope, e) => {
+            e.stopPropagation();
+            scope.toggleFilter(false);
+        },
+        enter: (scope, e) => {
+            e.stopPropagation();
+            scope.filterChanged(false);
+        },
         a: [{
             modifiers: ['ctrlKey'],
             callback: (scope, e) => {

--- a/src/javascripts/Factories/hotkeyFactory.js
+++ b/src/javascripts/Factories/hotkeyFactory.js
@@ -289,7 +289,7 @@ ngapp.service('hotkeyFactory', function() {
         },
         enter: (scope, e) => {
             e.stopPropagation();
-            scope.filterChanged(false);
+            scope.selectNextFiltered();
         },
         a: [{
             modifiers: ['ctrlKey'],


### PR DESCRIPTION
# Summary

Two major enhancements have been made to the filtering capabilities of `listView`:

1. Pressing <kbd>Enter</kbd> cycles through selection of all matches. If it reaches the last match, then it cycles back to the first match.
2. A box can be checked to only show items that match the filter. This can be freely toggled on and off.

# Implementation

The first feature is fairly straight forward to implement. However, the second added significant complexity. Some things I had to do:

* Add an Angular filter on the items, which is triggered whenever a filter changes or the toggle to only show matches changes. This re-applies all filters if only matches are chosen to be shown.
* Keep track of the previous index both for the entire array and for the filtered one. The index for the `items` array cannot be set directly. Instead, the filtered index has a setter which is responsible for updating both values to ensure they stay in sync. I'm not a big fan of this approach. I think it's confusing to keep track of two previous indices, but I haven't come up with a better solution yet.
* Add a `watchCollection` for the array of filtered items. This is used to convert the previous index when the checkbox for only showing matches is toggled.

# Known Issues

### Angular Filter Triggers Unnecessarily

Something I cannot figure out is why the Angular filter is triggered (sometimes twice in a row) for seemingly unnecessary actions e.g. just clicking on an empty space in the list or selecting an item. It happens even when `items` is the only parameter to the filter function. This is only evident if a breakpoint is set in that function.

This Angular filter may be redundant anyway. Perhaps it's feasible to manually update an array of filtered items. After all, it needs to update when either the items change, the filters change, or the toggle changes, and there are event handlers/watchers for each of those already.

### Possibly Redundant Call When Array Updates

The `watchCollection` calls `$scope.filterChanged()`, but in retrospect I am not sure if that's necessary. The original line of thinking was that the array may be updated by inserting or deleting an item somehow, in which case the filters would have to be re-applied and a new first index computed.

### Selected Item May Be Out of View

When toggling only showing matches, it does not scroll to the selected item again, meaning it may go out of view. Since the currently selected index is not tracked, there's no way to know where to scroll to. It could do a linear search for the first selected index, but not sure if that's worth it. Always tracking the index as a variable seems annoying since it has to get converted sometimes like the previous index is currently converted.