### PR TITLE
fix(relinker): Fixed replacement by searching by lower-case filenames

### DIFF
--- a/src/javascripts/Services/merge/relinker.js
+++ b/src/javascripts/Services/merge/relinker.js
@@ -56,9 +56,10 @@ ngapp.service('relinker', function(scriptsCache, bsaHelpers, pexService, setting
                 if (methodName !== 'GetFormFromFile') return;
                 let filename = resolveString(script, n.arguments[5]);
                 log(`Found GetFormFromFile call targetting ${filename}`, true);
-                if (!fidMap.hasOwnProperty(filename)) return;
+                let mapping = cUtils.findValueInMapByLoweredKey(fidMap, filename);
+                if (!mapping) return;
                 let oldFormId = xelib.Hex(n.arguments[4].data, 6),
-                    newFormId = fidMap[filename][oldFormId];
+                    newFormId = mapping[oldFormId];
                 if (!newFormId) return log(`Form ID ${oldFormId} not renumbered`);
                 log(`Changing Form ID from ${oldFormId} to ${newFormId}`);
                 n.arguments[4].data = parseInt(newFormId, 16);
@@ -69,7 +70,7 @@ ngapp.service('relinker', function(scriptsCache, bsaHelpers, pexService, setting
     let fixStrings = function(script, merges) {
         let mergedPlugins = getMergedPlugins(merges);
         script.stringTable.forEach((str, index) => {
-            let newStr = mergedPlugins[str];
+            let newStr = cUtils.findValueInMapByLoweredKey(mergedPlugins, str);
             if (!newStr) return;
             log(`Changing string ${index} from ${str} to ${newStr}`);
             script.stringTable[index] = newStr;

--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -9,6 +9,7 @@ import 'angularjs-scroll-glue';
 import { remote, ipcRenderer, clipboard } from 'electron';
 import jetpack from 'fs-jetpack';
 import fh from './helpers/fileHelpers';
+import cUtils from './helpers/collectionsUtils';
 import Logger from './helpers/logger.js';
 import { Ini } from 'ini-api';
 import buildModuleService from './helpers/moduleService';

--- a/src/javascripts/helpers/collectionsUtils.js
+++ b/src/javascripts/helpers/collectionsUtils.js
@@ -1,0 +1,13 @@
+let cUtils = {};
+
+cUtils.findValueInMapByLoweredKey = function (mapping, key) {
+    if (mapping && key) {
+        let res = Object.entries(mapping).find(kv => kv[0] && kv[0].toString().toLowerCase() === key.toLowerCase());
+        if (res) {
+            return res[1];
+        }
+    }
+    return undefined;
+}
+
+export default cUtils;


### PR DESCRIPTION
# Situation

- We have plugin called "MySuperPlugin.esp"
- We have script called "MySuperScript.pex" that contains code 'game.GetFormFromFile(1, "mySuperPlugin.esp")'
OR
We have script called "MySuperScript.pex" that contains code 'String EspFile = "mySuperPlugin.esp"'

## Without ZMerge

- Game loads such plugins and scripts without issues, cause Windows doesn't differentiate "MySuperPlugin.esp" and "mySuperPlugin.esp". 
- **Expected = Actual**

## With ZMerge

- We have ZMerge that contains "MySuperPlugin.esp" and a result plugin called "MySuperMerge.esp"
- Relinker tries to re-link "MySuperScript.pex" but skips 'game.GetFormFromFile(1, "mySuperPlugin.esp")' cause there is no exact match.
- Relinker tries to re-link "MySuperScript.pex" but skips 'String EspFile = "mySuperPlugin.esp"' cause there is no exact match.
- **Expected != Actual**

## Proposed solution

To do a lower-cased search that this pull request implements.
[X] **Expected = Actual**

### Small note

The function that does lower-cased search moved to the "collectionUtils" helper to be re-used in case of future changes, but it's can be moved directly to "relinkedService" to reduce changes.